### PR TITLE
fix get_discount_rules admin API

### DIFF
--- a/src/com/aria/common/rest/admin/RestUtilities.java
+++ b/src/com/aria/common/rest/admin/RestUtilities.java
@@ -547,7 +547,7 @@ public class RestUtilities {
         return returnElement;
     }
 
-    public static ArrayList<DiscountRuleReturnElement> buildDiscountRuleReturnElement(JSONArray jsonArray) {
+    public static ArrayList<DiscountRuleReturnElement> buildDiscountRulesReturnElement(JSONArray jsonArray) {
         ArrayList<DiscountRuleReturnElement> returnElement = new ArrayList<DiscountRuleReturnElement>();
         if (jsonArray == null) return returnElement;
         for (int i = 0;i < jsonArray.size();i++) {

--- a/src/com/aria/sdk/classes/AriaBillingAdministrationRest.java
+++ b/src/com/aria/sdk/classes/AriaBillingAdministrationRest.java
@@ -1591,13 +1591,7 @@ public class AriaBillingAdministrationRest extends BaseAriaBilling implements Ar
 
         returnValues[0] = "error_code";
         returnValues[1] = "error_msg";
-        returnValues[2] = "rule_no";
-        returnValues[3] = "rule_id";
-        returnValues[4] = "description";
-        returnValues[5] = "ext_description";
-        returnValues[6] = "flat_percent_ind";
-        returnValues[7] = "amount";
-        returnValues[8] = "currency";
+        returnValues[2] = "discount_rules";
         
         buildHashMapReturnValues(ret,returnValues);
         return getHashMapReturnValues();


### PR DESCRIPTION
The method getDiscountRules() should process the "discount_rules" field of JSON response.
I believe, the method buildDiscountRuleReturnElement() should be buildDiscountRulesReturnElement() to be compatible with the naming scheme. 